### PR TITLE
add dockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Utiliser une image Ubuntu comme base
+FROM ubuntu:latest
+
+# Installer les outils de compilation C
+RUN apt-get update && apt-get install -y gcc
+
+# Définir le répertoire de travail
+WORKDIR /app
+
+# Copier les fichiers source de votre application C dans le conteneur
+COPY main.c /app
+COPY textFile/scenario.txt /app/textFile/scenario.txt
+COPY textFile/logs.txt /app/textFile/logs.txt
+
+# Compiler votre application C
+RUN gcc -o application_c main.c
+
+# Exposer un point d'entrée pour lancer votre application
+CMD ["./application_c", "cat /textFile/logs.txt"]


### PR DESCRIPTION
Dockerfile pour créer une image docker. 
Celle-ci est basé sur une image ubuntu en sa dernière version (`:lastest`) 
On la màj et on install gcc avec la commande `RUN apt-get update && apt-get install -y gcc`
On créer un nouveau folder `/app`
On COPY du pc vers l'image les fichiers qui nous intéresse (le code C + les fichiers txt) 
On compile
On lance des commandes CMD (basé sur l'arch linux) -> 


>` ./application_c` va lancer le binaire compiler auparavant 

> `cat ....` va nous afficher le contenu du fichier `logs.txt` avant que le container ne meurt.

---------------------------- 
Pour faire fonctionner ce code -> utiliser la bonne version du main (avec les chemin simplifier) 
Remplacer dans le dockerFile les bons PATH (qui mène au fichier txt) qui correspondent à l’architecture de la machine
Lancer dockerDesktop 
Lancer les commandes : 

- [ ] ` docker build -t mon_app .` --> va build l'image docker via le dockerFile (on lui donne accès à tout l'env via le `.`) 
- [ ] `docker run mon_app` --> va lancer un container avec l'image docker build auparavant.
